### PR TITLE
add node version requirement to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@
 
 ## Requirements:
 
-`Nodejs 14`
+* Nodejs 14
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,12 @@
 
 ---
 
+## Requirements:
+
+`Nodejs 14`
+
+---
+
 ## Start dev (not implemented / will see errors for now!):
 
 `npm run start:dev`


### PR DESCRIPTION
What? 
Update the readme to include Node version requirements of node version: 14 and above. Have a look at other projects in node and see what their readmes a like with regards to requirements of node

Why?
As per the error Thomas ran into here: https://dreamteam2hq.slack.com/archives/C05033AVABV/p1679957839505949, it looks like the Node version needs to be > 14

ClickUp task:
https://app.clickup.com/t/860qby77a